### PR TITLE
自動読み込みの不具合修正

### DIFF
--- a/back/src/app/controllers/v1/room_posts_controller.rb
+++ b/back/src/app/controllers/v1/room_posts_controller.rb
@@ -56,7 +56,7 @@ class V1::RoomPostsController < ApplicationController
   end
 
   def _params!(key)
-    return nil unless params.key?(key)
+    return nil if params[key].nil?
     raise BadRequest, code: "invalid_#{key}" unless params[key].is_a?(String)
     _path_params!(key)
   end

--- a/front/src/components/Post/PostList.tsx
+++ b/front/src/components/Post/PostList.tsx
@@ -1,6 +1,6 @@
-import { Box, List, ListItem } from '@mui/material';
+import { Box, CircularProgress, List, ListItem } from '@mui/material';
 import type { ListProps } from '@mui/material';
-import { useRef, FC } from 'react';
+import { useState, useRef, FC } from 'react';
 
 import { PartPostList } from './PartPostList';
 import { SendPostForm } from './SendPostForm';
@@ -13,25 +13,48 @@ type PostListProps = {
 const postsLimit = 15;
 
 export const PostList: FC<PostListProps> = ({ roomId, sx }) => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
   const ref = useRef<HTMLDivElement>(null);
-  // TODO: 画面が縦長の場合、
+  const postRef = useRef<HTMLDivElement>(null);
+
   const scrollPostsToBottom = (behavior?: ScrollOptions['behavior']) => {
     if (ref?.current) ref.current.scrollTo({ top: ref.current.scrollHeight, behavior });
   };
 
   return (
     <List sx={sx}>
-      <Box maxHeight='60vh' sx={{ overflowY: 'auto' }} ref={ref}>
-        <PartPostList
-          roomId={roomId}
-          limit={postsLimit}
-          outerRef={ref}
-          onLoaded={() => {
-            scrollPostsToBottom();
-          }}
-        />
+      <Box maxHeight='55vh' sx={{ overflowY: isLoading ? 'hidden' : 'auto' }} ref={ref}>
+        {isLoading && (
+          <Box
+            position='absolute'
+            display='flex'
+            width='100%'
+            height='85%'
+            alignItems='center'
+            justifyContent='center'
+          >
+            <CircularProgress />
+          </Box>
+        )}
+        <Box visibility={isLoading ? 'hidden' : 'visible'} ref={postRef}>
+          <PartPostList
+            roomId={roomId}
+            limit={postsLimit}
+            outerRef={ref}
+            onLoaded={(count) => {
+              const h = ref.current?.clientHeight;
+              const ph = postRef.current?.clientHeight;
+              if (h && ph && (ph - 10 > h || count < postsLimit) && isLoading) {
+                setIsLoading(false);
+                scrollPostsToBottom();
+              }
+            }}
+          />
+        </Box>
       </Box>
-      <ListItem sx={{ m: '1.5rem 0' }}>
+      {/* FIXME: 送信したものが追加されない ... */}
+      <ListItem sx={{ m: '1.5rem 0', visibility: isLoading ? 'hidden' : 'visible' }}>
         <SendPostForm
           roomId={roomId}
           onSent={() => {

--- a/front/src/components/Progress/Progress.tsx
+++ b/front/src/components/Progress/Progress.tsx
@@ -1,4 +1,5 @@
 import { Box, CircularProgress, Typography } from '@mui/material';
+import type { BoxProps } from '@mui/material';
 import { useEffect, FC } from 'react';
 import type { DependencyList, EffectCallback, ReactNode } from 'react';
 
@@ -6,13 +7,14 @@ import { ProgressStatus } from '../../store';
 import type { ProgressType } from '../../store';
 
 type ProgressProp = {
+  sx?: BoxProps['sx'];
   children: ReactNode;
   callback: EffectCallback;
   deps?: DependencyList;
   status: ProgressType;
 };
 
-export const Progress: FC<ProgressProp> = ({ children, callback, deps, status }) => {
+export const Progress: FC<ProgressProp> = ({ sx, children, callback, deps, status }) => {
   useEffect(() => {
     callback();
   }, deps);
@@ -22,12 +24,13 @@ export const Progress: FC<ProgressProp> = ({ children, callback, deps, status })
   if (status === ProgressStatus.SUCCESS) return <> {children} </>;
 
   return (
-    <Box m={2}>
+    <Box sx={sx}>
       <CircularProgress size={30} />
     </Box>
   );
 };
 
 Progress.defaultProps = {
+  sx: { m: 2 },
   deps: [],
 };


### PR DESCRIPTION
## 概要
メッセージの自動読み込みの不具合を修正しました。

メッセージ表示領域のスクロールバーが最上位にきてしまうと、
既存メッセージを全て取得するまで、リクエストが送信されてしまう点の修正となります。

その他の変更点として、メッセージ取得が完了するまで、インジケーターを表示するようにいたしました。

## 関連 PR
#19